### PR TITLE
adds shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+with (import <nixpkgs> {});
+mkShell {
+  buildInputs = with pkgs; [
+    python39
+  ];
+  nativeBuildInputs = with pkgs.python39Packages; [
+    discordpy
+    requests
+  ];
+}


### PR DESCRIPTION
I'm not sure if buildInputs and nativeBuildInputs are the right order... but at least this is the most sane way